### PR TITLE
Add icu4c to macOS build

### DIFF
--- a/base/action.yml
+++ b/base/action.yml
@@ -32,8 +32,9 @@ runs:
       if: runner.os == 'macOS'
       shell: bash
       run: |
-        echo "LD_LIBRARY_PATH=/usr/local/lib"                                                                                 >> $GITHUB_ENV
-        echo "PKG_CONFIG_PATH=/usr/local/opt/cardano/lib/pkgconfig:/usr/local/opt/openssl@1.1/lib/pkgconfig:$PKG_CONFIG_PATH" >> $GITHUB_ENV
+        echo "LD_LIBRARY_PATH=/usr/local/lib" >> $GITHUB_ENV
+        echo "PKG_CONFIG_PATH=/usr/local/opt/cardano/lib/pkgconfig:/usr/local/opt/openssl@1.1/lib/pkgconfig:/usr/local/opt/icu4c/lib/pkgconfig:$PKG_CONFIG_PATH" \
+          >> $GITHUB_ENV
 
     # There are three pkg-config packages available for mingw, and each one has their problems:
     #


### PR DESCRIPTION
Add `icu4c` to macOS builds. Note that ICU is already installed on macOS, but still needs to be added to `pkg-config`.

Before this change, depending on `text-icu` will result in:
```
[__1] next goal: text-icu (dependency of haskell-build-test)
[__1] rejecting: text-icu-0.8.0.2, text-icu-0.8.0.1 (conflict: pkg-config
package icu-i18n>=62.1, not found in the pkg-config database)
[__1] rejecting: text-icu-0.8.0 (conflict: pkg-config package icu-i18n-any,
not found in the pkg-config database)
```

Afterwards, it should build successfully. Here are some tests I ran:

Before: https://github.com/sgillespie/haskell-build-test/actions/runs/5379724334/jobs/9761372648
After: https://github.com/sgillespie/haskell-build-test/actions/runs/5379724332/jobs/9761372656