### PR TITLE
Assert the path of the `devx` derivation retrieved from the closure

### DIFF
--- a/devx/action.yml
+++ b/devx/action.yml
@@ -40,4 +40,6 @@ runs:
       shell: bash
       run: |
         ${{ github.action_path }}/support/fetch-docker.sh input-output-hk/devx ${{ inputs.platform }}.${{ inputs.compiler-nix-name }}${{ inputs.target-platform }}${{ inputs.minimal && '-minimal' || '' }}${{ inputs.iog && '-iog' || '' }}-env | zstd -d | nix-store --import | tee store-paths.txt
-        sudo ln -s $(tail -n 1 store-paths.txt) /usr/local/bin/devx
+        DEVX_DRV=$(tail -n 1 store-paths.txt)
+        if [[ ! $DEVX_DRV =~ "devx" ]]; then exit 1; fi
+        sudo ln -s $DEVX_DRV /usr/local/bin/devx

--- a/devx/action.yml
+++ b/devx/action.yml
@@ -41,5 +41,9 @@ runs:
       run: |
         ${{ github.action_path }}/support/fetch-docker.sh input-output-hk/devx ${{ inputs.platform }}.${{ inputs.compiler-nix-name }}${{ inputs.target-platform }}${{ inputs.minimal && '-minimal' || '' }}${{ inputs.iog && '-iog' || '' }}-env | zstd -d | nix-store --import | tee store-paths.txt
         DEVX_DRV=$(tail -n 1 store-paths.txt)
+        # assert that the last path is actually the 'devx' script. If not we should not push this closure
+        # as it will result in us uploading broken closures, that can not be used. We expect the last path
+        # to be the devx script when pulling the pseudo-docker images down, and importing it into the
+        # /nix/store. If it's anything else, we'll end up with all kinds of weird behaviours.
         if [[ ! $DEVX_DRV =~ "devx" ]]; then exit 1; fi
         sudo ln -s $DEVX_DRV /usr/local/bin/devx


### PR DESCRIPTION
This allows to fail early when a user rely on this GA and the archive downloaded from ghcr.io is faulty.