### PR TITLE
Create a `cache` action to cache HLS artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This GitHub Action let you run commands into [the slightly opinionated `devx` sh
 | `compiler-nix-name` | Specifies the GHC version to use. The version should be provided without dots, for example, GHC 8.10.7 should be written as `ghc8107`. | `ghc961` |
 | `minimal` | A Boolean input to decide whether to include `hlint` and HLS in the build. Set to `false` to include these tools. | `true` |
 | `iog` | Another Boolean input that, when set to `true`, will include `libsodum`, `libsecp256k1`, and `libblst` in the build. | `false` |
-| `iog-full` | Same than `-iog` bit also include `R` and `postgresql` | `false` |
+| `iog-full` | Same than `iog` bit also include `R` and `postgresql` | `false` |
 
 Here's how you might utilize this action in your workflow:
 

--- a/cache/action.yml
+++ b/cache/action.yml
@@ -1,0 +1,16 @@
+name: 'Cache HLS artifacts'
+description: 'This is used to speed up GitHub Codespaces bootstrapping'
+inputs:
+  ghc_version:
+    description: GHC version used (cache is per-commit and per-GHC version)
+    type: string
+
+runs:
+  using: "composite"
+  steps:
+    - name: Cache build artifacts (used to speed up GitHub Codespaces bootstrapping)
+      uses: actions/upload-artifact@v4
+      with:
+        name: cache-${{ github.event.pull_request.head.sha }}-${{ inputs.ghc_version }}
+        path: |
+          ./dist-newstyle


### PR DESCRIPTION
This is used e.g. by https://github.com/IntersectMBO/cardano-base/pull/465 to speed up GitHub Codespaces bootstrapping