### PR TITLE
Install ghcup if it's not already present

### DIFF
--- a/haskell/action.yml
+++ b/haskell/action.yml
@@ -21,6 +21,17 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Install ghcup
+      shell: bash
+      run: |
+        if ! type ghcup &>/dev/null; then
+          curl -sSf https://get-ghcup.haskell.org |
+            BOOTSTRAP_HASKELL_NONINTERACTIVE=yes \
+            BOOTSTRAP_HASKELL_MINIMAL=yes \
+            bash
+          echo "PATH=$HOME/.ghcup/bin:$HOME/.cabal/bin:$PATH" >>"$GITHUB_ENV"
+        fi
+
     - name: Setup GHC
       if: inputs.ghc-version != ''
       shell: bash


### PR DESCRIPTION
It seems unwise to assume that `ghcup` will be in the runner environment.

In addition, when using [nektos/act](https://github.com/nektos/act) to test actions locally, `ghcup` isn't found and workflows using `actions/haskell` fail. This change fixes that. It does nothing if `ghcup` is already present, so there's no cost when running on the real GHA runner.

This is a recreation of #20 which can't be reopened because I deleted and recreated my fork.

cc @jasagredo 