### PR TITLE
Fix recent GHA images issues

### DIFF
--- a/base/action.yml
+++ b/base/action.yml
@@ -35,7 +35,7 @@ runs:
       shell: bash
       run: |
         echo "LD_LIBRARY_PATH=/usr/local/lib" >> $GITHUB_ENV
-        echo "PKG_CONFIG_PATH=/opt/homebrew/opt/openssl@3.0/lib/pkgconfig:/usr/local/opt/cardano/lib/pkgconfig:/usr/local/opt/openssl@1.1/lib/pkgconfig:/usr/local/opt/icu4c/lib/pkgconfig:$PKG_CONFIG_PATH" \
+        echo "PKG_CONFIG_PATH=/usr/local/opt/cardano/lib/pkgconfig:/opt/homebrew/opt/openssl@3.0/lib/pkgconfig:/usr/local/opt/icu4c/lib/pkgconfig:$PKG_CONFIG_PATH" \
           >> $GITHUB_ENV
 
     # There are three pkg-config packages available for mingw, and each one has their problems:

--- a/base/action.yml
+++ b/base/action.yml
@@ -21,9 +21,9 @@ runs:
 
         mkdir __prep__
         pushd __prep__
-          curl -sL ${{ inputs.url-prefix }}/macos.${{ inputs.use-sodium-vrf == 'true' && 'libsodium-vrf' || 'libsodium' }}.pkg > libsodium.pkg
-          curl -sL ${{ inputs.url-prefix }}/macos.libsecp256k1.pkg > libsecp256k1.pkg
-          curl -sL ${{ inputs.url-prefix }}/macos.libblst.pkg      > libblst.pkg
+          curl -sL ${{ inputs.url-prefix }}/$(uname -m)-macos.${{ inputs.use-sodium-vrf == 'true' && 'libsodium-vrf' || 'libsodium' }}.pkg > libsodium.pkg
+          curl -sL ${{ inputs.url-prefix }}/$(uname -m)-macos.libsecp256k1.pkg > libsecp256k1.pkg
+          curl -sL ${{ inputs.url-prefix }}/$(uname -m)-macos.libblst.pkg      > libblst.pkg
           for pkg in *.pkg; do
             sudo installer -pkg $pkg -target /
           done

--- a/base/action.yml
+++ b/base/action.yml
@@ -17,7 +17,7 @@ runs:
       if: runner.os == 'macOS'
       shell: bash
       run: |
-        brew install pkg-config
+        brew install pkg-config openssl@3.0
 
         mkdir __prep__
         pushd __prep__
@@ -35,7 +35,7 @@ runs:
       shell: bash
       run: |
         echo "LD_LIBRARY_PATH=/usr/local/lib" >> $GITHUB_ENV
-        echo "PKG_CONFIG_PATH=/usr/local/opt/cardano/lib/pkgconfig:/usr/local/opt/openssl@1.1/lib/pkgconfig:/usr/local/opt/icu4c/lib/pkgconfig:$PKG_CONFIG_PATH" \
+        echo "PKG_CONFIG_PATH=/opt/homebrew/opt/openssl@3.0/lib/pkgconfig:/usr/local/opt/cardano/lib/pkgconfig:/usr/local/opt/openssl@1.1/lib/pkgconfig:/usr/local/opt/icu4c/lib/pkgconfig:$PKG_CONFIG_PATH" \
           >> $GITHUB_ENV
 
     # There are three pkg-config packages available for mingw, and each one has their problems:
@@ -60,7 +60,8 @@ runs:
         mv /c/Strawberry/perl/bin/pkg-config     /c/Strawberry/perl/bin/perl-pkg-config
         mv /c/Strawberry/perl/bin/pkg-config.bat /c/Strawberry/perl/bin/perl-pkg-config.bat
 
-        /usr/bin/pacman --noconfirm -S mingw-w64-x86_64-pkg-config mingw-w64-x86_64-openssl
+        /usr/bin/pacman --noconfirm -S mingw-w64-x86_64-pkg-config
+
         echo "PKG_CONFIG_ALLOW_SYSTEM_CFLAGS=1" >> $GITHUB_ENV
         echo "PKG_CONFIG_ALLOW_SYSTEM_LIBS=1"   >> $GITHUB_ENV
 
@@ -69,6 +70,8 @@ runs:
           curl -sL ${{ inputs.url-prefix }}/msys2.${{ inputs.use-sodium-vrf == 'true' && 'libsodium-vrf' || 'libsodium' }}.pkg.tar.zstd > libsodium.pkg.tar.zstd
           curl -sL ${{ inputs.url-prefix }}/msys2.libsecp256k1.pkg.tar.zstd > libsecp256k1.pkg.tar.zstd
           curl -sL ${{ inputs.url-prefix }}/msys2.libblst.pkg.tar.zstd      > libblst.pkg.tar.zstd
+          # OpenSSL .pc files are wrong in openssl-3.3.0 https://github.com/openssl/openssl/issues/24298
+          curl -sL https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-openssl-3.2.1-1-any.pkg.tar.zst > openssl.pkg.tar.zstd
           for pkg in *.zstd; do
             /usr/bin/pacman --noconfirm -U $pkg
           done

--- a/base/action.yml
+++ b/base/action.yml
@@ -69,7 +69,8 @@ runs:
         pushd __prep__
           curl -sL ${{ inputs.url-prefix }}/msys2.${{ inputs.use-sodium-vrf == 'true' && 'libsodium-vrf' || 'libsodium' }}.pkg.tar.zstd > libsodium.pkg.tar.zstd
           curl -sL ${{ inputs.url-prefix }}/msys2.libsecp256k1.pkg.tar.zstd > libsecp256k1.pkg.tar.zstd
-          curl -sL ${{ inputs.url-prefix }}/msys2.libblst.pkg.tar.zstd      > libblst.pkg.tar.zstd
+          # curl -sL ${{ inputs.url-prefix }}/msys2.libblst.pkg.tar.zstd      > libblst.pkg.tar.zstd
+          curl -sL  https://github.com/input-output-hk/iohk-nix/releases/download/v2.2/msys2.libblst.pkg.tar.zstd > libblst.pkg.tar.zstd
           # OpenSSL .pc files are wrong in openssl-3.3.0 https://github.com/openssl/openssl/issues/24298
           curl -sL https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-openssl-3.2.1-1-any.pkg.tar.zst > openssl.pkg.tar.zstd
           for pkg in *.zstd; do

--- a/base/action.yml
+++ b/base/action.yml
@@ -69,6 +69,23 @@ runs:
         pushd __prep__
           curl -sL ${{ inputs.url-prefix }}/msys2.${{ inputs.use-sodium-vrf == 'true' && 'libsodium-vrf' || 'libsodium' }}.pkg.tar.zstd > libsodium.pkg.tar.zstd
           curl -sL ${{ inputs.url-prefix }}/msys2.libsecp256k1.pkg.tar.zstd > libsecp256k1.pkg.tar.zstd
+          # For windows we need to rely on the v2.2 libblst, otherwise GHC's linker blows up due to
+          # 
+          # GHC runtime linker: fatal error: I found a duplicate definition for symbol
+          #    __blst_platform_cap
+          # whilst processing object file
+          #    C:\msys64\mingw64\opt\cardano\lib\libblst.a
+          # The symbol was previously defined in
+          #    C:\msys64\mingw64\opt\cardano\lib\libblst.a(#2:server.o)
+          # This could be caused by:
+          #    * Loading two different object files which export the same symbol
+          #    * Specifying the same object file twice on the GHCi command line
+          #    * An incorrect `package.conf' entry, causing some object to be
+          #      loaded twice.
+          # ghc-9.8.1.exe: Could not load Object Code C:\msys64\mingw64\opt\cardano\lib\libblst.a(#1:assembly.o).
+          #
+          # While we have this fixed in our custom GHCs in haskell.nix, it's not fixed upstream, and we can't trivially
+          # fix the windows bindists. Thus for now we just use the older libblst on windows :see_no_evil:
           # curl -sL ${{ inputs.url-prefix }}/msys2.libblst.pkg.tar.zstd      > libblst.pkg.tar.zstd
           curl -sL  https://github.com/input-output-hk/iohk-nix/releases/download/v2.2/msys2.libblst.pkg.tar.zstd > libblst.pkg.tar.zstd
           # OpenSSL .pc files are wrong in openssl-3.3.0 https://github.com/openssl/openssl/issues/24298

--- a/base/action.yml
+++ b/base/action.yml
@@ -35,7 +35,7 @@ runs:
       shell: bash
       run: |
         echo "LD_LIBRARY_PATH=/usr/local/lib" >> $GITHUB_ENV
-        echo "PKG_CONFIG_PATH=/usr/local/opt/cardano/lib/pkgconfig:/opt/homebrew/opt/openssl@3.0/lib/pkgconfig:/usr/local/opt/icu4c/lib/pkgconfig:$PKG_CONFIG_PATH" \
+        echo "PKG_CONFIG_PATH=/usr/local/opt/cardano/lib/pkgconfig:/usr/local/opt/openssl@3.0/lib/pkgconfig:/usr/local/opt/icu4c/lib/pkgconfig:$PKG_CONFIG_PATH" \
           >> $GITHUB_ENV
 
     # There are three pkg-config packages available for mingw, and each one has their problems:

--- a/haskell/action.yml
+++ b/haskell/action.yml
@@ -21,6 +21,41 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Install GHCup (Linux & MacOS)
+      if: runner.os != 'Windows'
+      shell: bash
+      run: |
+        if ! type ghcup &>/dev/null; then
+          export BOOTSTRAP_HASKELL_NONINTERACTIVE=1
+          export BOOTSTRAP_HASKELL_MINIMAL=1
+          export GHCUP_INSTALL_BASE_PREFIX=$HOME
+          ghcup_bin=$GHCUP_INSTALL_BASE_PREFIX/.ghcup/bin
+
+          # Install GHCup
+          curl --proto '=https' --tlsv1.2 -fsSL https://get-ghcup.haskell.org | sh > /dev/null 2>&1
+          echo "PATH=$ghcup_bin:$PATH" >> $GITHUB_ENV
+        fi
+
+    - name: Install GHCup (Windows)
+      if: runner.os == 'Windows'
+      shell: 'C:/msys64/usr/bin/bash.exe -e {0}'
+      run: |
+        if ! type ghcup &>/dev/null; then
+          export BOOTSTRAP_HASKELL_NONINTERACTIVE=1
+          export BOOTSTRAP_HASKELL_MINIMAL=1
+          export GHCUP_INSTALL_BASE_PREFIX="/c/"
+          ghcup_bin=$GHCUP_INSTALL_BASE_PREFIX/ghcup/bin
+
+          # Install GHCup
+          curl --proto '=https' --tlsv1.2 -fsSL https://get-ghcup.haskell.org | sh > /dev/null 2>&1
+        fi
+
+    - name: Extend PATH (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        "PATH=C:\\ghcup\\bin;C:\\cabal\\bin;{0}" -f $env:PATH  >> $env:GITHUB_ENV
+
     - name: Setup GHC
       if: inputs.ghc-version != ''
       shell: bash


### PR DESCRIPTION
- OpenSSL@3.3.0 is broken in Windows. Downgraded to openssl 3.2.1. See https://github.com/openssl/openssl/issues/24298.
- OpenSSL@3.3.0 is broken in macOS. Downgrading to openssl 3.0.1.
- GHCup was removed from macOS. Now this action installs it if missing in all OSes.