### PR TITLE
Support macos-latest

### DIFF
--- a/base/action.yml
+++ b/base/action.yml
@@ -35,7 +35,9 @@ runs:
       shell: bash
       run: |
         echo "LD_LIBRARY_PATH=/usr/local/lib" >> $GITHUB_ENV
-        echo "PKG_CONFIG_PATH=/usr/local/opt/cardano/lib/pkgconfig:/usr/local/opt/openssl@3.0/lib/pkgconfig:/usr/local/opt/icu4c/lib/pkgconfig:$PKG_CONFIG_PATH" \
+        # Note: we add both /opt/homebrew/opt and /usr/local/opt for homebrews openssl@3.0, this is 
+        #       because different GitHub Runner at different revisions have different homebrew opt layouts.
+        echo "PKG_CONFIG_PATH=/usr/local/opt/cardano/lib/pkgconfig:/opt/homebrew/opt/openssl@3.0/lib/pkgconfig:/usr/local/opt/openssl@3.0/lib/pkgconfig:/usr/local/opt/icu4c/lib/pkgconfig:$PKG_CONFIG_PATH" \
           >> $GITHUB_ENV
 
     # There are three pkg-config packages available for mingw, and each one has their problems:


### PR DESCRIPTION
This adds /opt/homebrew/ as well as /usr/local/ as /opt/homebrew is required on macos-latest, while /usr/local/ is needed on prior ones.