### PR TITLE
Fix cabal-3.12 store path output in actions/haskell

### DIFF
--- a/haskell/action.yml
+++ b/haskell/action.yml
@@ -92,7 +92,10 @@ runs:
       run: |
         cabal help user-config
 
-        if [ "$(printf "3.10\n${{ inputs.cabal-version }}" | sort --version-sort | head -n 1)" = "3.10" ] && [ -n "$XDG_CONFIG_HOME" ]; then
+        if cabal path; then
+          # cabal >= 3.12 has `cabal path` command
+          echo "cabal-store=$(cabal path --store)" | tee -a "$GITHUB_OUTPUT"
+        elif [ "$(printf "3.10\n${{ inputs.cabal-version }}" | sort --version-sort | head -n 1)" = "3.10" ] && [ -n "$XDG_CONFIG_HOME" ]; then
           echo "Using xdg-config"
           cabal_config_file="$XDG_CONFIG_HOME/cabal/config"
           echo "cabal-store=$HOME/.local/state/cabal/store" | tee -a "$GITHUB_OUTPUT"


### PR DESCRIPTION
### What's that

Fixes https://github.com/input-output-hk/actions/issues/25

### Tests
I've used the following step to show the action output:
```yaml
    - name: list cache store dirs
      run: |
        cabal path --store-dir
        echo -e "\n\n${{ steps.setup-haskell.outputs.cabal-store }}"
```
Results:
* windows https://github.com/IntersectMBO/cardano-api/actions/runs/10113755891/job/27970817770#step:11:3
* ubuntu https://github.com/IntersectMBO/cardano-api/actions/runs/10113755891/job/27970817572#step:11:3
* macos https://github.com/IntersectMBO/cardano-api/actions/runs/10113755891/job/27970816281#step:11:3