### PR TITLE
Cabal >=3.12: handle additional output of `cabal path --store`

### DIFF
--- a/haskell/action.yml
+++ b/haskell/action.yml
@@ -94,7 +94,7 @@ runs:
 
         if cabal path; then
           # cabal >= 3.12 has `cabal path` command
-          echo "cabal-store=$(cabal path --store)" | tee -a "$GITHUB_OUTPUT"
+          echo "cabal-store=$(cabal path --store | tail -n 1)" | tee -a "$GITHUB_OUTPUT"
         elif [ "$(printf "3.10\n${{ inputs.cabal-version }}" | sort --version-sort | head -n 1)" = "3.10" ] && [ -n "$XDG_CONFIG_HOME" ]; then
           echo "Using xdg-config"
           cabal_config_file="$XDG_CONFIG_HOME/cabal/config"


### PR DESCRIPTION
When the `cabal.project` contains an s-r-p, invoking `cabal path --store` in a fresh project can return a line like

    HEAD is now at ...

before the actual store path, causing the logic here to fail.

Closes #27

See https://github.com/IntersectMBO/ouroboros-consensus/pull/1179 (https://github.com/IntersectMBO/ouroboros-consensus/commit/dd259c8f9e7ec916584cb583e5b970a6e0382ccf) for an example of this PR resolving the problem