### PR TITLE
Make MacOS dependencies installation overwrite installation path preventing symlink failures

### DIFF
--- a/base/action.yml
+++ b/base/action.yml
@@ -17,7 +17,7 @@ runs:
       if: runner.os == 'macOS'
       shell: bash
       run: |
-        brew install pkg-config openssl@3.0
+        brew install --overwrite pkg-config openssl@3.0
 
         mkdir __prep__
         pushd __prep__
@@ -35,7 +35,7 @@ runs:
       shell: bash
       run: |
         echo "LD_LIBRARY_PATH=/usr/local/lib" >> $GITHUB_ENV
-        # Note: we add both /opt/homebrew/opt and /usr/local/opt for homebrews openssl@3.0, this is 
+        # Note: we add both /opt/homebrew/opt and /usr/local/opt for homebrews openssl@3.0, this is
         #       because different GitHub Runner at different revisions have different homebrew opt layouts.
         echo "PKG_CONFIG_PATH=/usr/local/opt/cardano/lib/pkgconfig:/opt/homebrew/opt/openssl@3.0/lib/pkgconfig:/usr/local/opt/openssl@3.0/lib/pkgconfig:/usr/local/opt/icu4c/lib/pkgconfig:$PKG_CONFIG_PATH" \
           >> $GITHUB_ENV
@@ -72,7 +72,7 @@ runs:
           curl -sL ${{ inputs.url-prefix }}/msys2.${{ inputs.use-sodium-vrf == 'true' && 'libsodium-vrf' || 'libsodium' }}.pkg.tar.zstd > libsodium.pkg.tar.zstd
           curl -sL ${{ inputs.url-prefix }}/msys2.libsecp256k1.pkg.tar.zstd > libsecp256k1.pkg.tar.zstd
           # For windows we need to rely on the v2.2 libblst, otherwise GHC's linker blows up due to
-          # 
+          #
           # GHC runtime linker: fatal error: I found a duplicate definition for symbol
           #    __blst_platform_cap
           # whilst processing object file


### PR DESCRIPTION
MacOS workflows started recently failing with the following error:
```
Run brew install pkg-config openssl@3.0
  brew install pkg-config openssl@3.0
  
  mkdir __prep__
  pushd __prep__
    curl -sL https://github.com/input-output-hk/iohk-nix/releases/latest/download/$(uname -m)-macos.libsodium-vrf.pkg > libsodium.pkg
    curl -sL https://github.com/input-output-hk/iohk-nix/releases/latest/download/$(uname -m)-macos.libsecp256k1.pkg > libsecp256k1.pkg
    curl -sL https://github.com/input-output-hk/iohk-nix/releases/latest/download/$(uname -m)-macos.libblst.pkg      > libblst.pkg
    for pkg in *.pkg; do
      sudo installer -pkg $pkg -target /
    done
  popd
  rm -fR __prep__
  shell: /bin/bash --noprofile --norc -e -o pipefail {0}
  env:
    CABAL_CACHE_VERSION: 2024-07-26
    MSYS2_PATH_TYPE: inherit
    MSYSTEM: MINGW64
    PATH: /Users/runner/.ghcup/bin:/opt/homebrew/lib/ruby/gems/3.0.0/bin:/opt/homebrew/opt/ruby@3.0/bin:/Users/runner/.local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/Users/runner/.cargo/bin:/usr/local/opt/curl/bin:/usr/local/bin:/usr/local/sbin:/Users/runner/bin:/Users/runner/.yarn/bin:/Users/runner/Library/Android/sdk/tools:/Users/runner/Library/Android/sdk/platform-tools:/Library/Frameworks/Python.framework/Versions/Current/bin:/Library/Frameworks/Mono.framework/Versions/Current/Commands:/usr/bin:/bin:/usr/sbin:/sbin:/Users/runner/.dotnet/tools
==> Downloading https://ghcr.io/v2/homebrew/core/pkgconf/manifests/2.3.0_1
==> Fetching pkgconf
==> Downloading https://ghcr.io/v2/homebrew/core/pkgconf/blobs/sha256:5f83615f295e78e593c767d84f3eddf61bfb0b849a1e6a5ea343506b30b2c620
==> Downloading https://ghcr.io/v2/homebrew/core/openssl/3.0/manifests/3.0.15
==> Fetching openssl@3.0
==> Downloading https://ghcr.io/v2/homebrew/core/openssl/3.0/blobs/sha256:5f48e4f3391e514597cf9959a95daaafc1295ce4df9a26964d3ce0cb705a041f
==> Pouring pkgconf--2.3.0_1.arm64_sonoma.bottle.tar.gz
Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /opt/homebrew
Could not symlink bin/pkg-config
Target /opt/homebrew/bin/pkg-config
is a symlink belonging to pkg-config@0.29.2. You can unlink it:
  brew unlink pkg-config@0.29.2

To force the link and overwrite all conflicting files:
  brew link --overwrite pkgconf

To list all files that would be deleted:
  brew link --overwrite pkgconf --dry-run

Possible conflicting files are:
/opt/homebrew/bin/pkg-config -> /opt/homebrew/Cellar/pkg-config@0.29.2/0.29.2_3/bin/pkg-config
/opt/homebrew/share/aclocal/pkg.m4 -> /opt/homebrew/Cellar/pkg-config@0.29.2/0.29.2_3/share/aclocal/pkg.m4
/opt/homebrew/share/man/man1/pkg-config.1 -> /opt/homebrew/Cellar/pkg-config@0.29.2/0.29.2_3/share/man/man1/pkg-config.1
==> Summary
🍺  /opt/homebrew/Cellar/pkgconf/2.3.0_1: 27 files, 474KB
==> Pouring openssl@3.0--3.0.15.arm64_sonoma.bottle.tar.gz
==> Caveats
A CA file has been bootstrapped using certificates from the system
keychain. To add additional certificates, place .pem files in
  /opt/homebrew/etc/openssl@3.0/certs

and run
  /opt/homebrew/opt/openssl@3.0/bin/c_rehash

openssl@3.0 is keg-only, which means it was not symlinked into /opt/homebrew,
because this is an alternate version of another formula.

If you need to have openssl@3.0 first in your PATH, run:
  echo 'export PATH="/opt/homebrew/opt/openssl@3.0/bin:$PATH"' >> /Users/runner/.bash_profile

For compilers to find openssl@3.0 you may need to set:
  export LDFLAGS="-L/opt/homebrew/opt/openssl@3.0/lib"
  export CPPFLAGS="-I/opt/homebrew/opt/openssl@3.0/include"

For pkg-config to find openssl@3.0 you may need to set:
  export PKG_CONFIG_PATH="/opt/homebrew/opt/openssl@3.0/lib/pkgconfig"
==> Summary
🍺  /opt/homebrew/Cellar/openssl@3.0/3.0.15: 6,563 files, 28.4MB
==> Caveats
==> openssl@3.0
A CA file has been bootstrapped using certificates from the system
keychain. To add additional certificates, place .pem files in
  /opt/homebrew/etc/openssl@3.0/certs

and run
  /opt/homebrew/opt/openssl@3.0/bin/c_rehash

openssl@3.0 is keg-only, which means it was not symlinked into /opt/homebrew,
because this is an alternate version of another formula.

If you need to have openssl@3.0 first in your PATH, run:
  echo 'export PATH="/opt/homebrew/opt/openssl@3.0/bin:$PATH"' >> /Users/runner/.bash_profile

For compilers to find openssl@3.0 you may need to set:
  export LDFLAGS="-L/opt/homebrew/opt/openssl@3.0/lib"
  export CPPFLAGS="-I/opt/homebrew/opt/openssl@3.0/include"

For pkg-config to find openssl@3.0 you may need to set:
  export PKG_CONFIG_PATH="/opt/homebrew/opt/openssl@3.0/lib/pkgconfig"
Error: Process completed with exit code 1.
```

This PR adds `--overwrite` to `brew install pkg-config openssl@3.0`:


```bash
brew install --overwrite pkg-config openssl@3.0
```


Runner details:
```
Current runner version: '2.321.0'
Operating System
  macOS
  14.7.1
  23H222
Runner Image
  Image: macos-14-arm64
  Version: 20241119.509
  Included Software: https://github.com/actions/runner-images/blob/macos-14-arm64/20241119.509/images/macos/macos-14-arm64-Readme.md
  Image Release: https://github.com/actions/runner-images/releases/tag/macos-14-arm64%2F20241119.509
Runner Image Provisioner
  2.0.384.1+6d6c56aa16f1b9c7dd7935df5d63980397e44def
```