### PR TITLE
Add a "basic-nix-cache" action

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,26 @@ This action will set GHC and Cabal as needed
     ghc-version: ${{ matrix.ghc }}
     cabal-version: 3.10.1.0
 ```
+
+## `basic-nix-cache` action
+
+This action will set up a GitHub cache as a local Nix binary cache:
+
+```
+- name: Install Nix
+  uses: cachix/install-nix-action@v30
+  with:
+    extra_nix_config: |
+      extra-substituters = file://${{ runner.temp }}/nix-binary-cache
+      extra-trusted-public-keys = ${{ env.NIX_SIGNING_PUBLIC_KEY }}
+      post-build-hook = ${{ runner.temp }}/post-build.sh
+
+- name: Cache Nix
+  uses: input-output-hk/actions/basic-nix-cache
+  with:
+    signing-private-key: ${{ env.NIX_SIGNING_PRIVATE_KEY }}
+    path: ${{ runner.temp }}/nix-binary-cache
+    key: ${{ runner.os }}-nix-cache-${{ hashFiles('flake.lock', 'Cargo.lock') }}
+    restore-keys: |
+      ${{ runner.os }}-nix-cache-
+```

--- a/basic-nix-cache/action.yml
+++ b/basic-nix-cache/action.yml
@@ -19,6 +19,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Nix cache
+      shell: bash
       run: |
         # Write out secret key
         echo "${{ inputs.signing-private-key }}" > "${{ runner.temp }}/nix-cache-secret.key"
@@ -46,8 +47,8 @@ runs:
         mkdir -p "${{ runner.temp }}/nix-binary-cache/nar"
 
     - name: Cache Nix
-        uses: actions/cache@v4
-        with:
-          path: ${{ inputs.path }}
-          key: ${{ inputs.key }}
-          restore-keys: ${{ inputs.restore-keys }}
+      uses: actions/cache@v4
+      with:
+        path: ${{ inputs.path }}
+        key: ${{ inputs.key }}
+        restore-keys: ${{ inputs.restore-keys }}

--- a/basic-nix-cache/action.yml
+++ b/basic-nix-cache/action.yml
@@ -1,0 +1,53 @@
+name: 'Nix Cache'
+description: 'Treat the GitHub cache as a local Nix binary cache'
+
+inputs:
+  signing-private-key:
+    description: 'Secret key for signing store paths'
+    required: true
+  path:
+    description: 'A list of files, directories, and wildcard patterns to cache and restore'
+    required: true
+  key:
+    description: 'An explicit key for restoring and saving the cache'
+    required: true
+  restore-keys:
+    description: 'An ordered multiline string listing the prefix-matched keys, that are used for restoring stale cache if no cache hit occurred for key. Note `cache-hit` returns false in this case.'
+    required: false
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Nix cache
+      run: |
+        # Write out secret key
+        echo "${{ inputs.signing-private-key }}" > "${{ runner.temp }}/nix-cache-secret.key"
+
+        # Write out script
+        cat <<EOF > "${{ runner.temp }}/post-build.sh"
+          #!/bin/sh
+          set -eux
+          set -f         # Disable globbing
+          export IFS=' ' # Separate paths by space
+          # Add nix executables to PATH
+          export PATH="$PATH:/nix/var/nix/profiles/default/bin"
+
+          echo "Signing paths" \$OUT_PATHS
+          nix store sign --key-file ${{ runner.temp }}/nix-cache-secret.key --recursive \$OUT_PATHS
+
+          echo "Uploading paths" \$OUT_PATHS
+          nix copy --to "file://${{ runner.temp }}/nix-binary-cache" \$OUT_PATHS
+        EOF
+
+        # Make it executable
+        chmod +x "${{ runner.temp }}/post-build.sh"
+
+        # Prepopulate nix cache dirs to avoid permission problems
+        mkdir -p "${{ runner.temp }}/nix-binary-cache/nar"
+
+    - name: Cache Nix
+        uses: actions/cache@v4
+        with:
+          path: ${{ inputs.path }}
+          key: ${{ inputs.key }}
+          restore-keys: ${{ inputs.restore-keys }}

--- a/basic-nix-cache/action.yml
+++ b/basic-nix-cache/action.yml
@@ -27,7 +27,7 @@ runs:
         # Write out script
         cat <<EOF > "${{ runner.temp }}/post-build.sh"
           #!/bin/sh
-          set -eux
+          set -eu
           set -f         # Disable globbing
           export IFS=' ' # Separate paths by space
           # Add nix executables to PATH


### PR DESCRIPTION
Create a new action "basic-nix-action" that treats the GitHub filesystem cache as a local nix binary cache. This should allow us to (hopefully) temporarily replace the Nix Magic Cache until it's updated to use the new GitHub API. 