### PR TITLE
Add an "attic" action

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,22 @@ This action will set up a GitHub cache as a local Nix binary cache:
     restore-keys: |
       ${{ runner.os }}-nix-cache-
 ```
+
+## `attic` action
+
+This action sets up a remote Attic cache:
+
+```
+- name: Install Nix
+  uses: cachix/install-nix-action@v30
+  with:
+    nix_path: nixpkgs=channel:nixos-unstable
+    github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
+- name: Cache Nix
+  uses: input-output-hk/actions/attic@latest
+  with:
+    endpoint: ${{ secrets.ATTIC_URL }}
+    cache: ${{ secrets.ATTIC_CACHE }}
+    access_token: ${{ secrets.ATTIC_TOKEN }}
+```

--- a/attic/action.yml
+++ b/attic/action.yml
@@ -1,0 +1,78 @@
+name: Attic Cache Action
+description: |
+  Caches Nix build artifacts with Attic.
+
+inputs:
+  endpoint:
+    description: Endpoint of the Attic server
+    required: true
+
+  cache:
+    description: |
+      The cache to configure. This can be either This can be either `servername:cachename`
+      or `cachename`.
+    required: true
+
+  access_token:
+    description: The authentication token for pushing and accessing private caches
+    required: true
+
+  nix_path:
+    description: |
+      Set NIX_PATH environment variable for installing attic-client. For example:
+      `nixpkgs=channel:nixos-unstable`
+    required: false
+
+runs:
+  using: composite
+
+  steps:
+    - name: Set up attic
+      shell: bash
+      run: |
+        if [[ -n "${{ inputs.nix_path }}" ]]; then
+          export NIX_PATH="${{ inputs.nix_path }}"
+        fi
+
+        # Nix binaries are not port of the root's $PATH
+        NIX_BIN_DIR="/nix/var/nix/profiles/default/bin"
+
+        # Install Attic client. Note that we we unset the post-build hook, because it
+        # would fail without attic
+        sudo --preserve-env=NIX_PATH "$NIX_BIN_DIR/nix-env" \
+          --install \
+          --option post-build-hook "" \
+          --file '<nixpkgs>' \
+          --attr attic-client
+
+        # Log into attic
+        attic login default "${{ inputs.endpoint }}" "${{ inputs.access_token }}"
+        attic use "${{ inputs.cache }}"
+
+    - name: Install post-build hook
+      shell: bash
+      run: |
+        # Create the post-build script
+        cat <<EOF > "${{ runner.temp }}/post-build.sh"
+        #!/bin/sh
+        set -euf
+
+        # Add nix executables to PATH
+        export PATH="\$PATH:/nix/var/nix/profiles/default/bin"
+        # Force attic to use the same config file from the post-build hook as it does
+        # outside of it. Note that $XDG_CONFIG_HOME gets expanded when we write this
+        # file, NOT when its executed.
+        export XDG_CONFIG_HOME=$XDG_CONFIG_HOME
+
+        if [ -n "\${OUT_PATHS:-}" ]; then
+          echo "Uploading paths" "\$OUT_PATHS"
+          exec attic push "${{ inputs.cache }}" \$OUT_PATHS
+        fi
+        EOF
+
+        # Make it executable
+        chmod +x "${{ runner.temp }}/post-build.sh"
+
+        # Install the post-build hook
+        sudo bash -c 'echo "post-build-hook = ${{ runner.temp }}/post-build.sh" >> /etc/nix/nix.conf'
+        sudo systemctl restart nix-daemon.service

--- a/attic/action.yml
+++ b/attic/action.yml
@@ -34,10 +34,10 @@ runs:
           export NIX_PATH="${{ inputs.nix_path }}"
         fi
 
-        # Nix binaries are not port of the root's $PATH
+        # Nix binaries are not part of the root's $PATH
         NIX_BIN_DIR="/nix/var/nix/profiles/default/bin"
 
-        # Install Attic client. Note that we we unset the post-build hook, because it
+        # Install Attic client. Note that we unset the post-build hook, because it
         # would fail without attic
         sudo --preserve-env=NIX_PATH "$NIX_BIN_DIR/nix-env" \
           --install \
@@ -67,6 +67,11 @@ runs:
         if [ -n "\${OUT_PATHS:-}" ]; then
           echo "Uploading paths" "\$OUT_PATHS"
           exec attic push "${{ inputs.cache }}" \$OUT_PATHS
+        fi
+
+        if [ -n "\${DRV_PATH:-}" ]; then
+          echo "Uploading derivation path" "$\DRV_PATH"
+          exec attic push "${{ inputs.cache }}" \$DRV_PATH"
         fi
         EOF
 


### PR DESCRIPTION
Add an `attic` action that:

 1. Adds an attic server as a cache to nix.conf
 2. Adds a post-build hook that uploads closures as they are built

Note that this only works with multi-user installation of Nix