### PR TITLE
Attic: Add support for macOS runners

### DIFF
--- a/attic/action.yml
+++ b/attic/action.yml
@@ -80,4 +80,9 @@ runs:
 
         # Install the post-build hook
         sudo bash -c 'echo "post-build-hook = ${{ runner.temp }}/post-build.sh" >> /etc/nix/nix.conf'
-        sudo systemctl restart nix-daemon.service
+
+        if [[ "${{ runner.os }}" = "Linux" ]]; then
+          sudo systemctl restart nix-daemon.service
+        elif [[ "${{ runner.os }}" = "macOS" ]]; then
+          sudo launchctl kickstart -k system/org.nixos.nix-daemon
+        fi

--- a/attic/action.yml
+++ b/attic/action.yml
@@ -59,10 +59,12 @@ runs:
 
         # Add nix executables to PATH
         export PATH="\$PATH:/nix/var/nix/profiles/default/bin"
+
         # Force attic to use the same config file from the post-build hook as it does
-        # outside of it. Note that $XDG_CONFIG_HOME gets expanded when we write this
-        # file, NOT when its executed.
-        export XDG_CONFIG_HOME=$XDG_CONFIG_HOME
+        # outside of it. Note that $XDG_CONFIG_HOME gets expanded when we write this 
+        # file, NOT when its executed. This trick does not seem to work in macOS, so we'll have to 
+        # fallback to a known good value.
+        export XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-~runner/.config}
 
         if [ -n "\${OUT_PATHS:-}" ]; then
           echo "Uploading paths" "\$OUT_PATHS"


### PR DESCRIPTION
There were several problems when running the Attic action on macOS runners:

 1. `systemctl` is not available
 2. `$XDG_CONFIG_HOME` is unset

We deal with (1) by using launchctl instead, which should work with the macOS multi-user installation. As for (2), we explicitly set `XDG_CONFIG_HOME` to the runners home directory, this seems to work with the rust library that looks up config files.