### PR TITLE
Use curl's `-S`/`--show-error` option to avoid mysterious failures

### DIFF
--- a/base/action.yml
+++ b/base/action.yml
@@ -21,9 +21,9 @@ runs:
 
         mkdir __prep__
         pushd __prep__
-          curl -sSL ${{ inputs.url-prefix }}/$(uname -m)-macos.${{ inputs.use-sodium-vrf == 'true' && 'libsodium-vrf' || 'libsodium' }}.pkg > libsodium.pkg
-          curl -sSL ${{ inputs.url-prefix }}/$(uname -m)-macos.libsecp256k1.pkg > libsecp256k1.pkg
-          curl -sSL ${{ inputs.url-prefix }}/$(uname -m)-macos.libblst.pkg      > libblst.pkg
+          curl -fsSL ${{ inputs.url-prefix }}/$(uname -m)-macos.${{ inputs.use-sodium-vrf == 'true' && 'libsodium-vrf' || 'libsodium' }}.pkg > libsodium.pkg
+          curl -fsSL ${{ inputs.url-prefix }}/$(uname -m)-macos.libsecp256k1.pkg > libsecp256k1.pkg
+          curl -fsSL ${{ inputs.url-prefix }}/$(uname -m)-macos.libblst.pkg      > libblst.pkg
           for pkg in *.pkg; do
             sudo installer -pkg $pkg -target /
           done
@@ -69,8 +69,8 @@ runs:
 
         mkdir __prep__
         pushd __prep__
-          curl -sSL ${{ inputs.url-prefix }}/msys2.${{ inputs.use-sodium-vrf == 'true' && 'libsodium-vrf' || 'libsodium' }}.pkg.tar.zstd > libsodium.pkg.tar.zstd
-          curl -sSL ${{ inputs.url-prefix }}/msys2.libsecp256k1.pkg.tar.zstd > libsecp256k1.pkg.tar.zstd
+          curl -fsSL ${{ inputs.url-prefix }}/msys2.${{ inputs.use-sodium-vrf == 'true' && 'libsodium-vrf' || 'libsodium' }}.pkg.tar.zstd > libsodium.pkg.tar.zstd
+          curl -fsSL ${{ inputs.url-prefix }}/msys2.libsecp256k1.pkg.tar.zstd > libsecp256k1.pkg.tar.zstd
           # For windows we need to rely on the v2.2 libblst, otherwise GHC's linker blows up due to
           #
           # GHC runtime linker: fatal error: I found a duplicate definition for symbol
@@ -88,8 +88,8 @@ runs:
           #
           # While we have this fixed in our custom GHCs in haskell.nix, it's not fixed upstream, and we can't trivially
           # fix the windows bindists. Thus for now we just use the older libblst on windows :see_no_evil:
-          # curl -sSL ${{ inputs.url-prefix }}/msys2.libblst.pkg.tar.zstd      > libblst.pkg.tar.zstd
-          curl -sSL  https://github.com/input-output-hk/iohk-nix/releases/download/v2.2/msys2.libblst.pkg.tar.zstd > libblst.pkg.tar.zstd
+          # curl -fsSL ${{ inputs.url-prefix }}/msys2.libblst.pkg.tar.zstd      > libblst.pkg.tar.zstd
+          curl -fsSL  https://github.com/input-output-hk/iohk-nix/releases/download/v2.2/msys2.libblst.pkg.tar.zstd > libblst.pkg.tar.zstd
           for pkg in *.zstd; do
             /usr/bin/pacman --noconfirm -U $pkg
           done
@@ -115,9 +115,9 @@ runs:
 
         mkdir __prep__
         pushd __prep__
-          curl -sSL ${{ inputs.url-prefix }}/debian.${{ inputs.use-sodium-vrf == 'true' && 'libsodium-vrf' || 'libsodium' }}.deb > libsodium.deb
-          curl -sSL ${{ inputs.url-prefix }}/debian.libsecp256k1.deb > libsecp256k1.deb
-          curl -sSL ${{ inputs.url-prefix }}/debian.libblst.deb      > libblst.deb
+          curl -fsSL ${{ inputs.url-prefix }}/debian.${{ inputs.use-sodium-vrf == 'true' && 'libsodium-vrf' || 'libsodium' }}.deb > libsodium.deb
+          curl -fsSL ${{ inputs.url-prefix }}/debian.libsecp256k1.deb > libsecp256k1.deb
+          curl -fsSL ${{ inputs.url-prefix }}/debian.libblst.deb      > libblst.deb
           for pkg in *.deb; do
             sudo dpkg -i $pkg
           done

--- a/base/action.yml
+++ b/base/action.yml
@@ -21,9 +21,9 @@ runs:
 
         mkdir __prep__
         pushd __prep__
-          curl -sL ${{ inputs.url-prefix }}/$(uname -m)-macos.${{ inputs.use-sodium-vrf == 'true' && 'libsodium-vrf' || 'libsodium' }}.pkg > libsodium.pkg
-          curl -sL ${{ inputs.url-prefix }}/$(uname -m)-macos.libsecp256k1.pkg > libsecp256k1.pkg
-          curl -sL ${{ inputs.url-prefix }}/$(uname -m)-macos.libblst.pkg      > libblst.pkg
+          curl -sSL ${{ inputs.url-prefix }}/$(uname -m)-macos.${{ inputs.use-sodium-vrf == 'true' && 'libsodium-vrf' || 'libsodium' }}.pkg > libsodium.pkg
+          curl -sSL ${{ inputs.url-prefix }}/$(uname -m)-macos.libsecp256k1.pkg > libsecp256k1.pkg
+          curl -sSL ${{ inputs.url-prefix }}/$(uname -m)-macos.libblst.pkg      > libblst.pkg
           for pkg in *.pkg; do
             sudo installer -pkg $pkg -target /
           done
@@ -69,8 +69,8 @@ runs:
 
         mkdir __prep__
         pushd __prep__
-          curl -sL ${{ inputs.url-prefix }}/msys2.${{ inputs.use-sodium-vrf == 'true' && 'libsodium-vrf' || 'libsodium' }}.pkg.tar.zstd > libsodium.pkg.tar.zstd
-          curl -sL ${{ inputs.url-prefix }}/msys2.libsecp256k1.pkg.tar.zstd > libsecp256k1.pkg.tar.zstd
+          curl -sSL ${{ inputs.url-prefix }}/msys2.${{ inputs.use-sodium-vrf == 'true' && 'libsodium-vrf' || 'libsodium' }}.pkg.tar.zstd > libsodium.pkg.tar.zstd
+          curl -sSL ${{ inputs.url-prefix }}/msys2.libsecp256k1.pkg.tar.zstd > libsecp256k1.pkg.tar.zstd
           # For windows we need to rely on the v2.2 libblst, otherwise GHC's linker blows up due to
           #
           # GHC runtime linker: fatal error: I found a duplicate definition for symbol
@@ -88,8 +88,8 @@ runs:
           #
           # While we have this fixed in our custom GHCs in haskell.nix, it's not fixed upstream, and we can't trivially
           # fix the windows bindists. Thus for now we just use the older libblst on windows :see_no_evil:
-          # curl -sL ${{ inputs.url-prefix }}/msys2.libblst.pkg.tar.zstd      > libblst.pkg.tar.zstd
-          curl -sL  https://github.com/input-output-hk/iohk-nix/releases/download/v2.2/msys2.libblst.pkg.tar.zstd > libblst.pkg.tar.zstd
+          # curl -sSL ${{ inputs.url-prefix }}/msys2.libblst.pkg.tar.zstd      > libblst.pkg.tar.zstd
+          curl -sSL  https://github.com/input-output-hk/iohk-nix/releases/download/v2.2/msys2.libblst.pkg.tar.zstd > libblst.pkg.tar.zstd
           for pkg in *.zstd; do
             /usr/bin/pacman --noconfirm -U $pkg
           done
@@ -115,9 +115,9 @@ runs:
 
         mkdir __prep__
         pushd __prep__
-          curl -sL ${{ inputs.url-prefix }}/debian.${{ inputs.use-sodium-vrf == 'true' && 'libsodium-vrf' || 'libsodium' }}.deb > libsodium.deb
-          curl -sL ${{ inputs.url-prefix }}/debian.libsecp256k1.deb > libsecp256k1.deb
-          curl -sL ${{ inputs.url-prefix }}/debian.libblst.deb      > libblst.deb
+          curl -sSL ${{ inputs.url-prefix }}/debian.${{ inputs.use-sodium-vrf == 'true' && 'libsodium-vrf' || 'libsodium' }}.deb > libsodium.deb
+          curl -sSL ${{ inputs.url-prefix }}/debian.libsecp256k1.deb > libsecp256k1.deb
+          curl -sSL ${{ inputs.url-prefix }}/debian.libblst.deb      > libblst.deb
           for pkg in *.deb; do
             sudo dpkg -i $pkg
           done

--- a/devx/action.yml
+++ b/devx/action.yml
@@ -53,7 +53,7 @@ runs:
     - name: Install jq
       shell: bash
       run: |
-        curl -L https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -o jq
+        curl -fL https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -o jq
         chmod +x jq
     - name: Download and import closure
       shell: bash

--- a/devx/support/fetch-docker.sh
+++ b/devx/support/fetch-docker.sh
@@ -1,10 +1,11 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-TOKEN=$(curl --silent https://ghcr.io/token\?scope\=repository:$1:pull | jq -r .token)
+TOKEN=$(curl --silent --show-error "https://ghcr.io/token\?scope\=repository:$1:pull" | jq -r .token)
 
 # Read the manifest file from the docker image containing our nix-store closure and extract the layer url.
 BLOB=$(curl \
 --silent \
+--show-error \
 --request 'GET' \
 --header "Authorization: Bearer $TOKEN" \
 --header "Accept: application/vnd.docker.distribution.manifest.list.v2+json" \

--- a/devx/support/fetch-docker.sh
+++ b/devx/support/fetch-docker.sh
@@ -1,9 +1,16 @@
 #!/usr/bin/env bash
 
-TOKEN=$(curl --silent --show-error "https://ghcr.io/token\?scope\=repository:$1:pull" | jq -r .token)
+TOKEN=$(curl \
+--fail \
+--location \
+--silent \
+--show-error \
+"https://ghcr.io/token\?scope\=repository:$1:pull" | jq -r .token)
 
 # Read the manifest file from the docker image containing our nix-store closure and extract the layer url.
 BLOB=$(curl \
+--fail \
+--location \
 --silent \
 --show-error \
 --request 'GET' \
@@ -15,6 +22,7 @@ BLOB=$(curl \
 
 # Download the docker image layer that contains our nix store closure, and import it.
 curl \
+--fail \
 --location \
 --request GET \
 --header "Authorization: Bearer ${TOKEN}" \


### PR DESCRIPTION
If there's an infrastructure failure on GitHub, `curl` with `-s`/`--silent` will fail without a message and it's not obvious what's wrong. Adding `-S`/`--show-error` causes errors to be shown even when `-s`/`--silent` is used.