### PR TITLE
Fix broken URL in `fetch-docker.sh`

### DIFF
--- a/devx/support/fetch-docker.sh
+++ b/devx/support/fetch-docker.sh
@@ -5,7 +5,7 @@ TOKEN=$(curl \
 --location \
 --silent \
 --show-error \
-"https://ghcr.io/token\?scope\=repository:$1:pull" | jq -r .token)
+"https://ghcr.io/token?scope=repository:$1:pull" | jq -r .token)
 
 # Read the manifest file from the docker image containing our nix-store closure and extract the layer url.
 BLOB=$(curl \


### PR DESCRIPTION
The escapes are unnecessary and carry over into the actual URL