### PR TITLE
base: enable long file paths for Git on Windows

### DIFF
--- a/base/action.yml
+++ b/base/action.yml
@@ -106,6 +106,16 @@ runs:
         "PATH=C:\\msys64\\mingw64\\opt\\cardano\\bin;C:\\msys64\\mingw64\\bin;{0}" -f $env:PATH  >> $env:GITHUB_ENV
         "PKG_CONFIG_PATH=C:\\msys64\\mingw64\\opt\\cardano\\lib\\pkgconfig;C:\\msys64\\mingw64\\lib\\pkgconfig;C:\\msys64\\mingw64\\share\\pkgconfig;C:\\msys64\\usr\\lib\\pkgconfig;C:\\msys64\\usr\\share\\pkgconfig;{0}" -f $env:PKG_CONFIG_PATH >> $env:GITHUB_ENV
 
+    # Git for Windows refuses to create paths longer than 260 characters unless
+    # core.longpaths is set. The repositories themselves stay under the limit, but
+    # git operations that clone other repos on the runner can exceed it: cabal
+    # fetches source-repository-packages into dist-newstyle/src/<name>-<hash>/,
+    # whose prefix alone is ~120 characters.
+    - name: "[windows] Enable long file paths for Git"
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: git config --system core.longpaths true
+
     - name: "[linux] Install library dependencies"
       if: runner.os == 'Linux'
       shell: bash


### PR DESCRIPTION
Git for Windows fails on paths longer than 260 characters unless core.longpaths is enabled; cabal clones source-repository-packages into deep dist-newstyle subdirectories where pinned dependencies can exceed that, so enable it for every consumer of the base action instead of repeating the step in each repository workflow (cardano-node already carries it inline; a cardano-api PR was asked to move it here).

See https://github.com/IntersectMBO/cardano-api/pull/1316#pullrequestreview-5008999275